### PR TITLE
Pass `begin` on calls to `WriteEvents()`.

### DIFF
--- a/aggregate/event_test.go
+++ b/aggregate/event_test.go
@@ -63,25 +63,23 @@ type eventWriterStub struct {
 	WriteEventsFunc func(
 		ctx context.Context,
 		hk, id string,
-		end uint64,
+		begin, end uint64,
 		events []*envelopespec.Envelope,
-		archive bool,
 	) error
 }
 
 func (s *eventWriterStub) WriteEvents(
 	ctx context.Context,
 	hk, id string,
-	end uint64,
+	begin, end uint64,
 	events []*envelopespec.Envelope,
-	archive bool,
 ) error {
 	if s.WriteEventsFunc != nil {
-		return s.WriteEventsFunc(ctx, hk, id, end, events, archive)
+		return s.WriteEventsFunc(ctx, hk, id, begin, end, events)
 	}
 
 	if s.EventWriter != nil {
-		return s.EventWriter.WriteEvents(ctx, hk, id, end, events, archive)
+		return s.EventWriter.WriteEvents(ctx, hk, id, begin, end, events)
 	}
 
 	return nil
@@ -108,7 +106,7 @@ func expectEvents(
 
 		producedEvents = append(producedEvents, events...)
 
-		if begin >= end {
+		if begin == end {
 			break
 		}
 

--- a/aggregate/worker_test.go
+++ b/aggregate/worker_test.go
@@ -199,10 +199,10 @@ var _ = Describe("type Worker", func() {
 					"<handler-key>",
 					"<instance>",
 					0,
+					0,
 					[]*envelopespec.Envelope{
 						NewEnvelope("<existing>", MessageX1),
 					},
-					false, // archive
 				)
 				Expect(err).ShouldNot(HaveOccurred())
 			})
@@ -307,11 +307,11 @@ var _ = Describe("type Worker", func() {
 					ctx,
 					"<handler-key>",
 					"<instance>",
+					0,
 					1,
 					[]*envelopespec.Envelope{
 						NewEnvelope("<existing>", MessageX1),
 					},
-					false, // archive
 				)
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -422,11 +422,11 @@ var _ = Describe("type Worker", func() {
 					"<handler-key>",
 					"<instance>",
 					0,
+					0,
 					[]*envelopespec.Envelope{
 						NewEnvelope("<existing-1>", MessageX1),
 						NewEnvelope("<existing-2>", MessageX2),
 					},
-					false, // archive
 				)
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -705,9 +705,8 @@ var _ = Describe("type Worker", func() {
 			eventWriter.WriteEventsFunc = func(
 				ctx context.Context,
 				hk, id string,
-				end uint64,
+				begin, end uint64,
 				events []*envelopespec.Envelope,
-				archive bool,
 			) error {
 				return errors.New("<error>")
 			}

--- a/persistence/internal/persistencetest/event.go
+++ b/persistence/internal/persistencetest/event.go
@@ -2,6 +2,7 @@ package persistencetest
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	dogmafixtures "github.com/dogmatiq/dogma/fixtures"
@@ -15,10 +16,10 @@ import (
 
 // AggregateEventContext encapsulates values used during event tests.
 type AggregateEventContext struct {
-	Reader              aggregate.EventReader
-	Writer              aggregate.EventWriter
-	ArchiveIsSoftDelete bool
-	AfterEach           func()
+	Reader                      aggregate.EventReader
+	Writer                      aggregate.EventWriter
+	CanReadRevisionsBeforeBegin bool
+	AfterEach                   func()
 }
 
 // DeclareAggregateEventTests declares a function test-suite for persistence of
@@ -27,9 +28,9 @@ func DeclareAggregateEventTests(
 	new func() AggregateEventContext,
 ) {
 	var (
-		tc        AggregateEventContext
-		ctx       context.Context
-		allEvents []*envelopespec.Envelope
+		tc                                                   AggregateEventContext
+		ctx                                                  context.Context
+		eventA, eventB, xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx []*envelopespec.Envelope
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -37,13 +38,16 @@ func DeclareAggregateEventTests(
 		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 		ginkgo.DeferCleanup(cancel)
 
-		allEvents = []*envelopespec.Envelope{
+		xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = []*envelopespec.Envelope{
 			veracityfixtures.NewEnvelope("<event-0>", dogmafixtures.MessageA1),
 			veracityfixtures.NewEnvelope("<event-1>", dogmafixtures.MessageB1),
 			veracityfixtures.NewEnvelope("<event-2>", dogmafixtures.MessageC1),
 			veracityfixtures.NewEnvelope("<event-4>", dogmafixtures.MessageD1),
 			veracityfixtures.NewEnvelope("<event-5>", dogmafixtures.MessageE1),
 		}
+
+		eventA = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx[:1]
+		eventB = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx[1:2]
 
 		tc = new()
 		if tc.AfterEach != nil {
@@ -63,35 +67,60 @@ func DeclareAggregateEventTests(
 			gomega.Expect(end).To(gomega.BeNumerically("==", 0))
 		})
 
-		ginkgo.It("returns [0, 1) after a single write", func() {
-			err := tc.Writer.WriteEvents(
-				ctx,
-				"<handler>",
-				"<instance>",
-				0,
-				allEvents,
-				false, // archive
-			)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		ginkgo.It("returns [0, n) after n writes", func() {
+			for rev := uint64(0); rev < 3; rev++ {
+				err := tc.Writer.WriteEvents(
+					ctx,
+					"<handler>",
+					"<instance>",
+					0,
+					rev,
+					eventA,
+				)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-			begin, end, err := tc.Reader.ReadBounds(
-				ctx,
-				"<handler>",
-				"<instance>",
-			)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			gomega.Expect(begin).To(gomega.BeNumerically("==", 0))
-			gomega.Expect(end).To(gomega.BeNumerically("==", 1))
+				begin, end, err := tc.Reader.ReadBounds(
+					ctx,
+					"<handler>",
+					"<instance>",
+				)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				gomega.Expect(begin).To(gomega.BeNumerically("==", 0))
+				gomega.Expect(end).To(gomega.BeNumerically("==", rev+1))
+			}
 		})
 
-		ginkgo.It("returns [0, 2) after two writes", func() {
+		ginkgo.It("returns [n, n) when begin == end", func() {
+			for rev := uint64(0); rev < 3; rev++ {
+				err := tc.Writer.WriteEvents(
+					ctx,
+					"<handler>",
+					"<instance>",
+					rev+1,
+					rev,
+					eventA,
+				)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+				begin, end, err := tc.Reader.ReadBounds(
+					ctx,
+					"<handler>",
+					"<instance>",
+				)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				gomega.Expect(begin).To(gomega.BeNumerically("==", rev+1))
+				gomega.Expect(end).To(gomega.BeNumerically("==", rev+1))
+			}
+		})
+
+		ginkgo.It("returns [n-1, n) when there is a revision written after setting begin == end", func() {
 			err := tc.Writer.WriteEvents(
 				ctx,
 				"<handler>",
 				"<instance>",
+				1,
 				0,
-				allEvents,
-				false, // archive
+				eventA,
 			)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
@@ -100,70 +129,8 @@ func DeclareAggregateEventTests(
 				"<handler>",
 				"<instance>",
 				1,
-				allEvents,
-				false, // archive
-			)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-			begin, end, err := tc.Reader.ReadBounds(
-				ctx,
-				"<handler>",
-				"<instance>",
-			)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			gomega.Expect(begin).To(gomega.BeNumerically("==", 0))
-			gomega.Expect(end).To(gomega.BeNumerically("==", 2))
-		})
-
-		ginkgo.It("returns [n, n) when all events are archived", func() {
-			err := tc.Writer.WriteEvents(
-				ctx,
-				"<handler>",
-				"<instance>",
-				0,
-				allEvents,
-				false, // archive
-			)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-			err = tc.Writer.WriteEvents(
-				ctx,
-				"<handler>",
-				"<instance>",
 				1,
-				allEvents,
-				true, // archive
-			)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-			begin, end, err := tc.Reader.ReadBounds(
-				ctx,
-				"<handler>",
-				"<instance>",
-			)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			gomega.Expect(begin).To(gomega.BeNumerically("==", 2))
-			gomega.Expect(end).To(gomega.BeNumerically("==", 2))
-		})
-
-		ginkgo.It("returns [n-1, n) when there is a revision written after archiving", func() {
-			err := tc.Writer.WriteEvents(
-				ctx,
-				"<handler>",
-				"<instance>",
-				0,
-				allEvents,
-				true, // archive
-			)
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-			err = tc.Writer.WriteEvents(
-				ctx,
-				"<handler>",
-				"<instance>",
-				1,
-				allEvents,
-				false, // archive
+				eventA,
 			)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
@@ -179,7 +146,7 @@ func DeclareAggregateEventTests(
 	})
 
 	ginkgo.Describe("func ReadEvents()", func() {
-		ginkgo.When("no writes have occurred", func() {
+		ginkgo.When("there are no historical events", func() {
 			ginkgo.It("returns 0 events when starting at revision 0", func() {
 				events, end, err := tc.Reader.ReadEvents(
 					ctx,
@@ -205,27 +172,90 @@ func DeclareAggregateEventTests(
 			})
 		})
 
-		ginkgo.When("writes have occurred", func() {
+		ginkgo.When("there are no historical events, but there are prior revisions", func() {
 			ginkgo.BeforeEach(func() {
-				err := tc.Writer.WriteEvents(
+				for rev := uint64(0); rev < 3; rev++ {
+					err := tc.Writer.WriteEvents(
+						ctx,
+						"<handler>",
+						"<instance>",
+						0,
+						rev,
+						nil, // no events
+					)
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				}
+			})
+
+			ginkgo.It("returns 0 events when starting at revision 0", func() {
+				events, end, err := tc.Reader.ReadEvents(
 					ctx,
 					"<handler>",
 					"<instance>",
 					0,
-					allEvents[:3],
-					false, // archive
 				)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				gomega.Expect(events).To(gomega.BeEmpty())
+				gomega.Expect(end).To(gomega.BeNumerically("==", 3))
+			})
 
-				err = tc.Writer.WriteEvents(
+			ginkgo.It("returns 0 events when starting from a non-zero revision", func() {
+				events, end, err := tc.Reader.ReadEvents(
 					ctx,
 					"<handler>",
 					"<instance>",
 					1,
-					allEvents[3:],
-					false, // archive
 				)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				gomega.Expect(events).To(gomega.BeEmpty())
+				gomega.Expect(end).To(gomega.BeNumerically("==", 3))
+			})
+
+			ginkgo.It("returns 0 events when starting from a non-existent future revision", func() {
+				events, end, err := tc.Reader.ReadEvents(
+					ctx,
+					"<handler>",
+					"<instance>",
+					3,
+				)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				gomega.Expect(events).To(gomega.BeEmpty())
+				gomega.Expect(end).To(gomega.BeNumerically("==", 3))
+			})
+		})
+
+		ginkgo.When("there are historical events", func() {
+			var historicalEvents []*envelopespec.Envelope
+
+			ginkgo.BeforeEach(func() {
+				for rev := uint64(0); rev < 3; rev++ {
+					events := []*envelopespec.Envelope{
+						veracityfixtures.NewEnvelope(
+							"<event>",
+							dogmafixtures.MessageE{
+								Value: fmt.Sprintf("<event-%d-a>", rev),
+							},
+						),
+						veracityfixtures.NewEnvelope(
+							"<event>",
+							dogmafixtures.MessageE{
+								Value: fmt.Sprintf("<event-%d-b>", rev),
+							},
+						),
+					}
+
+					err := tc.Writer.WriteEvents(
+						ctx,
+						"<handler>",
+						"<instance>",
+						0,
+						rev,
+						events,
+					)
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+					historicalEvents = append(historicalEvents, events...)
+				}
 			})
 
 			ginkgo.It("returns the events in the order they were written", func() {
@@ -235,7 +265,7 @@ func DeclareAggregateEventTests(
 					"<handler>",
 					"<instance>",
 					0,
-					allEvents,
+					historicalEvents,
 				)
 			})
 
@@ -244,11 +274,11 @@ func DeclareAggregateEventTests(
 					ctx,
 					"<handler>",
 					"<instance>",
-					2,
+					3,
 				)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				gomega.Expect(events).To(gomega.BeEmpty())
-				gomega.Expect(end).To(gomega.BeNumerically("<=", 2))
+				gomega.Expect(end).To(gomega.BeNumerically("==", 3))
 			})
 
 			ginkgo.It("returns 0 events when starting from a non-existent future revision after the next revision", func() {
@@ -263,106 +293,22 @@ func DeclareAggregateEventTests(
 				gomega.Expect(end).To(gomega.BeNumerically("<=", 6))
 			})
 		})
-
-		ginkgo.When("there are archived events", func() {
-			ginkgo.BeforeEach(func() {
-				err := tc.Writer.WriteEvents(
-					ctx,
-					"<handler>",
-					"<instance>",
-					0,
-					allEvents[:3],
-					true, // archive
-				)
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
-
-			ginkgo.It("returns an error when the revision refers to an archived revision", func() {
-				if tc.ArchiveIsSoftDelete {
-					ginkgo.Skip("archived events are soft-deleted")
-				}
-
-				_, _, err := tc.Reader.ReadEvents(
-					ctx,
-					"<handler>",
-					"<instance>",
-					0,
-				)
-				gomega.Expect(err).To(gomega.MatchError("revision 0 is archived"))
-			})
-
-			ginkgo.It("does not return an error when the revision is after the last archived revision", func() {
-				err := tc.Writer.WriteEvents(
-					ctx,
-					"<handler>",
-					"<instance>",
-					1,
-					allEvents[3:],
-					false, // archive
-				)
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-				expectEvents(
-					ctx,
-					tc.Reader,
-					"<handler>",
-					"<instance>",
-					1,
-					allEvents[3:],
-				)
-			})
-		})
 	})
 
-	ginkgo.Describe("func WriteEvents()", func() {
-		ginkgo.When("no writes have occurred", func() {
-			ginkgo.It("returns an error if the given revision is not the (exclusive) end revision", func() {
-				err := tc.Writer.WriteEvents(
-					ctx,
-					"<handler>",
-					"<instance>",
-					3, // incorrect end revision
-					allEvents,
-					false, // archive
-				)
-				gomega.Expect(err).To(gomega.MatchError("optimistic concurrency conflict, 3 is not the next revision"))
-			})
-		})
-
-		ginkgo.When("writes have occurred", func() {
-			ginkgo.BeforeEach(func() {
-				err := tc.Writer.WriteEvents(
-					ctx,
-					"<handler>",
-					"<instance>",
-					0,
-					allEvents,
-					false, // archive
-				)
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
-
-			ginkgo.It("returns an error if the given revision is not the (exclusive) end revision", func() {
-				err := tc.Writer.WriteEvents(
-					ctx,
-					"<handler>",
-					"<instance>",
-					3, // incorrect end revision
-					allEvents,
-					false, // archive
-				)
-				gomega.Expect(err).To(gomega.MatchError("optimistic concurrency conflict, 3 is not the next revision"))
-			})
-		})
-
-		ginkgo.It("allows archiving without writing events", func() {
+	ginkgo.When("the begin offset has been advanced beyond zero", func() {
+		ginkgo.BeforeEach(func() {
 			err := tc.Writer.WriteEvents(
 				ctx,
 				"<handler>",
 				"<instance>",
 				0,
-				allEvents,
-				false, // archive
+				0,
+				[]*envelopespec.Envelope{
+					veracityfixtures.NewEnvelope(
+						"<archived-event>",
+						dogmafixtures.MessageX1,
+					),
+				},
 			)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
@@ -371,8 +317,108 @@ func DeclareAggregateEventTests(
 				"<handler>",
 				"<instance>",
 				1,
-				nil, // don't add more events
-				true,
+				1,
+				eventA,
+			)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			err = tc.Writer.WriteEvents(
+				ctx,
+				"<handler>",
+				"<instance>",
+				1,
+				2,
+				eventB,
+			)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("returns an error when reading from before the new begin revision", func() {
+			if tc.CanReadRevisionsBeforeBegin {
+				ginkgo.Skip("this implementation allows reading revisions before the begin revision")
+			}
+
+			_, _, err := tc.Reader.ReadEvents(
+				ctx,
+				"<handler>",
+				"<instance>",
+				0,
+			)
+			gomega.Expect(err).To(gomega.MatchError("revision 0 is archived"))
+		})
+
+		ginkgo.It("allows reading from the new begin revision", func() {
+			expectEvents(
+				ctx,
+				tc.Reader,
+				"<handler>",
+				"<instance>",
+				1,
+				append(eventA, eventB...),
+			)
+		})
+
+		ginkgo.It("allows reading after the new begin revision", func() {
+			expectEvents(
+				ctx,
+				tc.Reader,
+				"<handler>",
+				"<instance>",
+				2,
+				eventB,
+			)
+		})
+	})
+
+	ginkgo.Describe("func WriteEvents()", func() {
+		ginkgo.When("there are no existing revisions", func() {
+			ginkgo.It("returns an error if end is not zero", func() {
+				err := tc.Writer.WriteEvents(
+					ctx,
+					"<handler>",
+					"<instance>",
+					0,
+					3, // incorrect end revision
+					eventA,
+				)
+				gomega.Expect(err).To(gomega.MatchError("optimistic concurrency conflict, 3 is not the next revision"))
+			})
+		})
+
+		ginkgo.When("there are existing revisions", func() {
+			ginkgo.BeforeEach(func() {
+				err := tc.Writer.WriteEvents(
+					ctx,
+					"<handler>",
+					"<instance>",
+					0,
+					0,
+					eventA,
+				)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+
+			ginkgo.It("returns an error if the given revision already exists", func() {
+				err := tc.Writer.WriteEvents(
+					ctx,
+					"<handler>",
+					"<instance>",
+					0,
+					0, // incorrect end revision
+					eventB,
+				)
+				gomega.Expect(err).To(gomega.MatchError("optimistic concurrency conflict, 0 is not the next revision"))
+			})
+		})
+
+		ginkgo.It("allows increasing begin without writing any events", func() {
+			err := tc.Writer.WriteEvents(
+				ctx,
+				"<handler>",
+				"<instance>",
+				1,
+				0,
+				eventA,
 			)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
@@ -382,8 +428,8 @@ func DeclareAggregateEventTests(
 				"<instance>",
 			)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			gomega.Expect(begin).To(gomega.BeNumerically("==", 2))
-			gomega.Expect(end).To(gomega.BeNumerically("==", 2))
+			gomega.Expect(begin).To(gomega.BeNumerically("==", 1))
+			gomega.Expect(end).To(gomega.BeNumerically("==", 1))
 		})
 
 		ginkgo.It("stores separate bounds for each combination of handler key and instance ID", func() {
@@ -400,57 +446,53 @@ func DeclareAggregateEventTests(
 			}
 
 			for i, inst := range instances {
-				events := allEvents[:i]
-
 				var rev uint64
-				for _, ev := range events {
+
+				for j := 0; j < i; j++ {
 					err := tc.Writer.WriteEvents(
 						ctx,
 						inst.HandlerKey,
 						inst.InstanceID,
+						0,
 						rev,
-						[]*envelopespec.Envelope{ev},
-						false, // archive
+						eventA,
 					)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 					rev++
 				}
 
+				begin := rev + 1
 				err := tc.Writer.WriteEvents(
 					ctx,
 					inst.HandlerKey,
 					inst.InstanceID,
+					begin,
 					rev,
-					[]*envelopespec.Envelope{},
-					true, // archive
+					nil,
 				)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				rev++
 
-				for _, ev := range events {
-					err = tc.Writer.WriteEvents(
-						ctx,
-						inst.HandlerKey,
-						inst.InstanceID,
-						rev,
-						[]*envelopespec.Envelope{ev},
-						false, // archive
-					)
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-					rev++
-				}
+				err = tc.Writer.WriteEvents(
+					ctx,
+					inst.HandlerKey,
+					inst.InstanceID,
+					begin,
+					rev,
+					eventA,
+				)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			}
 
 			for i, inst := range instances {
+				expectedBegin := i + 1
+				expectedEnd := expectedBegin + 1
+
 				begin, end, err := tc.Reader.ReadBounds(
 					ctx,
 					inst.HandlerKey,
 					inst.InstanceID,
 				)
-
-				expectedBegin := i + 1
-				expectedEnd := (i * 2) + 1
-
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				gomega.Expect(begin).To(gomega.BeNumerically("==", expectedBegin))
 				gomega.Expect(end).To(gomega.BeNumerically("==", expectedEnd))
@@ -470,46 +512,26 @@ func DeclareAggregateEventTests(
 				{"<handler-2>", "<instance-2>"},
 			}
 
+			var envelopes []*envelopespec.Envelope
+
 			for i, inst := range instances {
-				events := allEvents[:i]
-
-				var rev uint64
-				for _, ev := range events {
-					err := tc.Writer.WriteEvents(
-						ctx,
-						inst.HandlerKey,
-						inst.InstanceID,
-						rev,
-						[]*envelopespec.Envelope{ev},
-						false, // archive
-					)
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-					rev++
-				}
-
+				env := veracityfixtures.NewEnvelope(
+					"<event>",
+					dogmafixtures.MessageE{
+						Value: fmt.Sprintf("<event-%d>", i),
+					},
+				)
 				err := tc.Writer.WriteEvents(
 					ctx,
 					inst.HandlerKey,
 					inst.InstanceID,
-					rev,
-					[]*envelopespec.Envelope{},
-					true, // archive
+					0,
+					0,
+					[]*envelopespec.Envelope{env},
 				)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-				rev++
 
-				for _, ev := range events {
-					err = tc.Writer.WriteEvents(
-						ctx,
-						inst.HandlerKey,
-						inst.InstanceID,
-						rev,
-						[]*envelopespec.Envelope{ev},
-						false, // archive
-					)
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-					rev++
-				}
+				envelopes = append(envelopes, env)
 			}
 
 			for i, inst := range instances {
@@ -518,8 +540,8 @@ func DeclareAggregateEventTests(
 					tc.Reader,
 					inst.HandlerKey,
 					inst.InstanceID,
-					uint64(i+1),
-					allEvents[:i],
+					0,
+					envelopes[i:i+1],
 				)
 			}
 		})
@@ -548,7 +570,7 @@ func expectEvents(
 
 		producedEvents = append(producedEvents, events...)
 
-		if begin >= end {
+		if begin == end {
 			break
 		}
 


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR changes the `EventWriter.WriteEvents()` method to accept the `begin` revision instead of the `archive` flag.

 I've also updated the documentation for the `EventReader` and `EventWriter` interfaces to more closely match the implementation requirements.

#### Why make this change?

Passing the `begin` revision directly correlates to the values that are returned by the `EventReader`, this helps keep these interfaces a little "dumber", they just persist what you tell them. It also simplifies some implementations by avoiding a read to lookup the begin revision in some circumstances.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
