### PR TITLE
Add `cluster.Partitioner`.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/aws/aws-sdk-go v1.44.258
+	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/onsi/ginkgo/v2 v2.9.4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aws/aws-sdk-go v1.44.258 h1:JVk1lgpsTnb1kvUw3eGhPLcTpEBp6HeSf1fxcYDs2Ho=
 github.com/aws/aws-sdk-go v1.44.258/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/internal/cluster/partition.go
+++ b/internal/cluster/partition.go
@@ -1,0 +1,66 @@
+package cluster
+
+import (
+	"sync"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/google/uuid"
+)
+
+// Partitioner determines which node is responsible for handling a specific
+// workload.
+type Partitioner struct {
+	m     sync.RWMutex
+	nodes map[uuid.UUID]struct{}
+}
+
+// AddNode adds a node to the partitioner.
+func (p *Partitioner) AddNode(id uuid.UUID) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	if p.nodes == nil {
+		p.nodes = map[uuid.UUID]struct{}{}
+	}
+
+	p.nodes[id] = struct{}{}
+}
+
+// RemoveNode removes a node from the partitioner.
+func (p *Partitioner) RemoveNode(id uuid.UUID) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	delete(p.nodes, id)
+}
+
+// Route returns the ID of the node that should handle the workload identified
+// by the given string.
+func (p *Partitioner) Route(workload string) uuid.UUID {
+	p.m.RLock()
+	defer p.m.RUnlock()
+
+	if len(p.nodes) == 0 {
+		panic("partitioner has no nodes")
+	}
+
+	var (
+		bestID    uuid.UUID
+		bestScore uint64
+		hash      xxhash.Digest
+	)
+
+	for id := range p.nodes {
+		hash.Write(id[:])
+		hash.WriteString(workload)
+		score := hash.Sum64()
+		hash.Reset()
+
+		if score > bestScore {
+			bestID = id
+			bestScore = score
+		}
+	}
+
+	return bestID
+}

--- a/internal/cluster/partition_test.go
+++ b/internal/cluster/partition_test.go
@@ -1,0 +1,83 @@
+package cluster_test
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/dogmatiq/veracity/internal/cluster"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Partitioner", func() {
+	var partitioner *cluster.Partitioner
+
+	BeforeEach(func() {
+		partitioner = &cluster.Partitioner{}
+	})
+
+	When("there are no nodes", func() {
+		It("panics", func() {
+			Expect(func() {
+				partitioner.Route("<workload>")
+			}).To(PanicWith("partitioner has no nodes"))
+		})
+	})
+
+	When("there are nodes", func() {
+		var nodes map[uuid.UUID]struct{}
+
+		BeforeEach(func() {
+			nodes = map[uuid.UUID]struct{}{}
+
+			for i := 0; i < 10; i++ {
+				id := uuid.New()
+				partitioner.AddNode(id)
+				nodes[id] = struct{}{}
+			}
+		})
+
+		It("distributes workloads across all nodes", func() {
+			start := time.Now()
+			timeout := 5 * time.Second
+
+			i := 0
+
+			// Loop as many times is possible with a different workload until
+			// each node is returned at least once.
+			for {
+				if time.Since(start) > timeout {
+					Expect(nodes).To(
+						BeEmpty(),
+						"timed-out waiting for workloads to be distributed",
+					)
+				}
+
+				id := partitioner.Route(strconv.Itoa(i))
+				i++
+
+				delete(nodes, id)
+
+				if len(nodes) == 0 {
+					break
+				}
+			}
+		})
+
+		It("consistently routes to a specific workload to the same node", func() {
+			id := partitioner.Route("<workload>")
+			for i := 0; i < 10; i++ {
+				Expect(partitioner.Route("<workload>")).To(Equal(id))
+			}
+		})
+
+		It("does not route to nodes that have been removed", func() {
+			removed := partitioner.Route("<workload>")
+			partitioner.RemoveNode(removed)
+
+			id := partitioner.Route("<workload>")
+			Expect(id).NotTo(Equal(removed))
+		})
+	})
+})


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR introduces the `cluster.Partitioner` struct.

#### Why make this change?

This struct implements the rendezvous hashing that will be used to determine which node within a cluster is responsible for any given workload.

#### Is there anything you are unsure about?

The `Partitioner` operates on node IDs (not the `cluster.Node` struct). I did this so that it can be used wherever node IDs are known, but perhaps the entire `Node` is not available. It might be more useful to switch to using `Node` in the future, or even make `Partitioner` a generic type that can map workloads to arbitrary node-related values (such as gRPC clients).

At any rate, I kept it simple for now.

#### What issues does this relate to?

...
