### PR TITLE
Add version as a param in function parameter of `persistence.Journal.Range()` method.

### DIFF
--- a/persistence/driver/aws/dynamodb/journal.go
+++ b/persistence/driver/aws/dynamodb/journal.go
@@ -170,7 +170,7 @@ func (j *journ) Get(ctx context.Context, ver uint64) ([]byte, bool, error) {
 func (j *journ) Range(
 	ctx context.Context,
 	ver uint64,
-	fn func(context.Context, []byte) (bool, error),
+	fn func(context.Context, uint64, []byte) (bool, error),
 ) error {
 	checkVersion := true
 
@@ -189,7 +189,7 @@ func (j *journ) Range(
 				checkVersion = false
 			}
 
-			return fn(ctx, rec)
+			return fn(ctx, v, rec)
 		},
 	)
 }

--- a/persistence/driver/memory/journal.go
+++ b/persistence/driver/memory/journal.go
@@ -82,7 +82,7 @@ func (h *journalHandle) Get(ctx context.Context, ver uint64) ([]byte, bool, erro
 func (h *journalHandle) Range(
 	ctx context.Context,
 	ver uint64,
-	fn func(context.Context, []byte) (bool, error),
+	fn func(context.Context, uint64, []byte) (bool, error),
 ) error {
 	if h.state == nil {
 		panic("journal is closed")
@@ -97,8 +97,9 @@ func (h *journalHandle) Range(
 		return fmt.Errorf("cannot range over truncated records")
 	}
 
-	for _, rec := range records[ver-begin:] {
-		ok, err := fn(ctx, slices.Clone(rec))
+	for i, rec := range records[ver-begin:] {
+		v := ver - begin + uint64(i)
+		ok, err := fn(ctx, v, slices.Clone(rec))
 		if !ok || err != nil {
 			return err
 		}

--- a/persistence/driver/memory/journal.go
+++ b/persistence/driver/memory/journal.go
@@ -97,8 +97,9 @@ func (h *journalHandle) Range(
 		return fmt.Errorf("cannot range over truncated records")
 	}
 
-	for i, rec := range records[ver-begin:] {
-		v := ver - begin + uint64(i)
+	start := ver - begin
+	for i, rec := range records[start:] {
+		v := start + uint64(i)
 		ok, err := fn(ctx, v, slices.Clone(rec))
 		if !ok || err != nil {
 			return err

--- a/persistence/driver/postgres/journal.go
+++ b/persistence/driver/postgres/journal.go
@@ -60,7 +60,7 @@ func (j *journ) Get(ctx context.Context, ver uint64) ([]byte, bool, error) {
 func (j *journ) Range(
 	ctx context.Context,
 	ver uint64,
-	fn func(context.Context, []byte) (bool, error),
+	fn func(context.Context, uint64, []byte) (bool, error),
 ) error {
 	rows, err := j.DB.QueryContext(
 		ctx,
@@ -93,7 +93,7 @@ func (j *journ) Range(
 		}
 		expectedVersion++
 
-		ok, err := fn(ctx, rec)
+		ok, err := fn(ctx, v, rec)
 		if !ok || err != nil {
 			return err
 		}

--- a/persistence/journal/journal.go
+++ b/persistence/journal/journal.go
@@ -18,7 +18,7 @@ type Journal interface {
 	Range(
 		ctx context.Context,
 		ver uint64,
-		fn func(ctx context.Context, rec []byte) (bool, error),
+		fn func(ctx context.Context, ver uint64, rec []byte) (bool, error),
 	) error
 
 	// RangeAll invokes fn for each record in the journal, in order.

--- a/persistence/journal/test.go
+++ b/persistence/journal/test.go
@@ -243,7 +243,7 @@ func RunTests(
 				if err := j.Range(
 					ctx,
 					expectVer,
-					func(ctx context.Context, rec []byte) (bool, error) {
+					func(ctx context.Context, ver uint64, rec []byte) (bool, error) {
 						actual = append(actual, rec)
 						return true, nil
 					},
@@ -275,7 +275,7 @@ func RunTests(
 				if err := j.Range(
 					ctx,
 					0,
-					func(ctx context.Context, rec []byte) (bool, error) {
+					func(ctx context.Context, ver uint64, rec []byte) (bool, error) {
 						if called {
 							return false, errors.New("unexpected call")
 						}
@@ -320,7 +320,7 @@ func RunTests(
 				err = j.Range(
 					ctx,
 					1,
-					func(ctx context.Context, rec []byte) (bool, error) {
+					func(ctx context.Context, ver uint64, rec []byte) (bool, error) {
 						panic("unexpected call")
 					},
 				)
@@ -350,7 +350,7 @@ func RunTests(
 				if err := j.Range(
 					ctx,
 					0,
-					func(ctx context.Context, rec []byte) (bool, error) {
+					func(ctx context.Context, ver uint64, rec []byte) (bool, error) {
 						rec[0] = 'X'
 
 						return true, nil

--- a/persistence/journal/test.go
+++ b/persistence/journal/test.go
@@ -244,7 +244,13 @@ func RunTests(
 					ctx,
 					expectVer,
 					func(ctx context.Context, ver uint64, rec []byte) (bool, error) {
+						if ver != expectVer {
+							t.Fatalf("unexpected version: want %d, got %d", expectVer, ver)
+						}
+
 						actual = append(actual, rec)
+						expectVer++
+
 						return true, nil
 					},
 				); err != nil {


### PR DESCRIPTION
#### What change does this introduce?

This PR attempts to make the signatures of parameter functions in `journal.Range` and `journal.RangeAll` methods consistent.


#### Why make this change?

This PR eases the use of `persistence.Journal` interface by attempting to make the signatures of parameter functions in `journal.Range` and `journal.RangeAll` methods consistent.


#### Is there anything you are unsure about?

I am not sure if I we need to test the new parameter (`ver`) in the tests asserting the behaviour of `Journal.Range()` method.

#### What issues does this relate to?

N/A
