### PR TITLE
Remove `Journal.RangeAll()`.

### DIFF
--- a/internal/protobuf/protojournal/range.go
+++ b/internal/protobuf/protojournal/range.go
@@ -9,8 +9,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// A RangeFunc is called by [Range] and [RangeAll] for each record in a
-// [journal.Journal].
+// A RangeFunc is called by [Range] for each record in a [journal.Journal].
 type RangeFunc[Record proto.Message] func(
 	ctx context.Context,
 	pos journal.Position,
@@ -31,31 +30,6 @@ func Range[
 	return j.Range(
 		ctx,
 		begin,
-		func(
-			ctx context.Context,
-			pos journal.Position,
-			data []byte,
-		) (bool, error) {
-			rec, err := typedproto.Unmarshal[Record](data)
-			if err != nil {
-				return false, fmt.Errorf("unable to unmarshal record: %w", err)
-			}
-			return fn(ctx, pos, rec)
-		},
-	)
-}
-
-// RangeAll invokes fn for each record in the journal, in order.
-func RangeAll[
-	Record typedproto.Message[Struct],
-	Struct typedproto.MessageStruct,
-](
-	ctx context.Context,
-	j journal.Journal,
-	fn RangeFunc[Record],
-) error {
-	return j.RangeAll(
-		ctx,
 		func(
 			ctx context.Context,
 			pos journal.Position,

--- a/internal/protobuf/protojournal/search.go
+++ b/internal/protobuf/protojournal/search.go
@@ -92,27 +92,6 @@ func Scan[
 	return value, ok, err
 }
 
-// ScanAll finds a value within the journal by scanning all records.
-func ScanAll[
-	T any,
-	Record typedproto.Message[Struct],
-	Struct typedproto.MessageStruct,
-](
-	ctx context.Context,
-	j journal.Journal,
-	scan ScanFunc[T, Record],
-) (value T, ok bool, err error) {
-	err = RangeAll(
-		ctx,
-		j,
-		func(ctx context.Context, pos journal.Position, rec Record) (bool, error) {
-			value, ok, err = scan(ctx, pos, rec)
-			return !ok, err
-		},
-	)
-	return value, ok, err
-}
-
 // ScanFromSearchResult finds a value within the journal by scanning all records
 // beginning with the for which cmp() returns true.
 func ScanFromSearchResult[

--- a/internal/telemetry/instrumentedpersistence/journal.go
+++ b/internal/telemetry/instrumentedpersistence/journal.go
@@ -145,37 +145,6 @@ func (j *journ) Range(
 	)
 	defer span.End()
 
-	return j.instrumentRange(
-		ctx,
-		span,
-		fn,
-		func(ctx context.Context, fn journal.RangeFunc) error {
-			return j.Next.Range(ctx, begin, fn)
-		},
-	)
-}
-
-func (j *journ) RangeAll(
-	ctx context.Context,
-	fn journal.RangeFunc,
-) error {
-	ctx, span := j.Telemetry.StartSpan(ctx, "journal.range_all")
-	defer span.End()
-
-	return j.instrumentRange(
-		ctx,
-		span,
-		fn,
-		j.Next.RangeAll,
-	)
-}
-
-func (j *journ) instrumentRange(
-	ctx context.Context,
-	span *telemetry.Span,
-	fn journal.RangeFunc,
-	doRange func(context.Context, journal.RangeFunc) error,
-) error {
 	var (
 		first, count journal.Position
 		totalSize    int64
@@ -184,8 +153,9 @@ func (j *journ) instrumentRange(
 
 	span.Debug("reading journal records")
 
-	err := doRange(
+	err := j.Next.Range(
 		ctx,
+		begin,
 		func(ctx context.Context, pos journal.Position, rec []byte) (bool, error) {
 			if count == 0 {
 				first = pos

--- a/persistence/driver/memory/journal.go
+++ b/persistence/driver/memory/journal.go
@@ -119,30 +119,6 @@ func (h *journalHandle) Range(
 	return ctx.Err()
 }
 
-func (h *journalHandle) RangeAll(
-	ctx context.Context,
-	fn journal.RangeFunc,
-) error {
-	if h.state == nil {
-		panic("journal is closed")
-	}
-
-	h.state.RLock()
-	pos := h.state.Begin
-	records := h.state.Records
-	h.state.RUnlock()
-
-	for _, rec := range records {
-		ok, err := fn(ctx, pos, slices.Clone(rec))
-		if !ok || err != nil {
-			return err
-		}
-		pos++
-	}
-
-	return ctx.Err()
-}
-
 func (h *journalHandle) Append(ctx context.Context, end journal.Position, rec []byte) error {
 	if h.state == nil {
 		panic("journal is closed")

--- a/persistence/driver/postgres/keyvalue.go
+++ b/persistence/driver/postgres/keyvalue.go
@@ -124,7 +124,7 @@ func (ks *keyspace) Range(
 			k []byte
 			v []byte
 		)
-		if err = rows.Scan(&k, &v); err != nil {
+		if err := rows.Scan(&k, &v); err != nil {
 			return err
 		}
 

--- a/persistence/journal/journal.go
+++ b/persistence/journal/journal.go
@@ -43,9 +43,6 @@ type Journal interface {
 	// It returns [ErrNotFound] if there is no record at the given position.
 	Range(ctx context.Context, pos Position, fn RangeFunc) error
 
-	// RangeAll invokes fn for each record in the journal, in order.
-	RangeAll(ctx context.Context, fn RangeFunc) error
-
 	// Append adds a record to the journal.
 	//
 	// end must be the next "unused" position in the journal; the first position


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/blob/main/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR removes the `Journal.RangeAll()` method.

#### Why make this change?

In the interest of keeping the `journal.Journal` interface as small as possible, so that new implementations are as easy as possible. The equivalent of `RangeAll()` can be achieved by first calling `Bounds()` then using `Range()`.  In the case of a journal that is never truncated, `Range()` with a `begin` value of `0` is also equivalent to `RangeAll()`.
